### PR TITLE
Implement Runtime Location Permissions for WiFi Scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,51 @@
+# Android Studio
+*.iml
+.gradle/
+build/
+.idea/
+local.properties
+
+# macOS
+.DS_Store
+
+# Kotlin/Java
+*.class
+*.log
+
+# Dependency Directories
+node_modules/
+
+# Gradle
+captures/
+.externalNativeBuild/
+.cxx/
+
+# Kotlin Native
+*.klib
+
+# Virtual Machine crash logs
+hs_err_pid*
+
+# Logs
+logs/
+*.log
+
+# Android Test Results
+app/build/
+testResults/
+
+# Temp files
+*.tmp
+*.bak
+*~
+
+# Sensitive Information
+*.env
+secrets.properties
+
+# Dependency cache
+.pnp/
+.pnp.js
+
+# Testing
+coverage/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    id("com.android.application")
+    kotlin("android")
+}
+
+dependencies {
+    // Android Core Dependencies
+    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("androidx.fragment:fragment-ktx:1.5.7")
+
+    // Test Dependencies
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("io.mockk:mockk:1.13.5")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.8.10")
+}

--- a/app/src/main/kotlin/com/wifiscanner/permissions/PermissionManager.kt
+++ b/app/src/main/kotlin/com/wifiscanner/permissions/PermissionManager.kt
@@ -1,0 +1,77 @@
+package com.wifiscanner.permissions
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+
+class PermissionManager {
+
+    companion object {
+        private const val LOCATION_PERMISSION_REQUEST_CODE = 1001
+        private val REQUIRED_PERMISSIONS = arrayOf(
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.ACCESS_COARSE_LOCATION
+        )
+
+        /**
+         * Check if location permissions are granted
+         * @param context Application context
+         * @return Boolean indicating if location permissions are granted
+         */
+        fun hasLocationPermissions(context: Context): Boolean {
+            return REQUIRED_PERMISSIONS.all { permission ->
+                ContextCompat.checkSelfPermission(
+                    context,
+                    permission
+                ) == PackageManager.PERMISSION_GRANTED
+            }
+        }
+
+        /**
+         * Request location permissions at runtime
+         * @param activity The current FragmentActivity
+         * @param onPermissionGranted Callback for when permissions are granted
+         * @param onPermissionDenied Callback for when permissions are denied
+         */
+        fun requestLocationPermissions(
+            activity: FragmentActivity,
+            onPermissionGranted: () -> Unit,
+            onPermissionDenied: () -> Unit
+        ) {
+            // Check if permissions are already granted
+            if (hasLocationPermissions(activity)) {
+                onPermissionGranted()
+                return
+            }
+
+            // Request permissions
+            ActivityCompat.requestPermissions(
+                activity,
+                REQUIRED_PERMISSIONS,
+                LOCATION_PERMISSION_REQUEST_CODE
+            )
+        }
+
+        /**
+         * Handle permission request results
+         * @param grantResults The grant results for the requested permissions
+         * @param onPermissionGranted Callback for when permissions are granted
+         * @param onPermissionDenied Callback for when permissions are denied
+         */
+        fun handlePermissionResult(
+            grantResults: IntArray,
+            onPermissionGranted: () -> Unit,
+            onPermissionDenied: () -> Unit
+        ) {
+            if (grantResults.isNotEmpty() && 
+                grantResults.all { it == PackageManager.PERMISSION_GRANTED }) {
+                onPermissionGranted()
+            } else {
+                onPermissionDenied()
+            }
+        }
+    }
+}

--- a/app/src/test/kotlin/com/wifiscanner/permissions/PermissionManagerTest.kt
+++ b/app/src/test/kotlin/com/wifiscanner/permissions/PermissionManagerTest.kt
@@ -1,0 +1,113 @@
+package com.wifiscanner.permissions
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.Assert.*
+
+class PermissionManagerTest {
+
+    private lateinit var mockContext: Context
+    private lateinit var mockActivity: FragmentActivity
+
+    @Before
+    fun setup() {
+        mockContext = mockk(relaxed = true)
+        mockActivity = mockk(relaxed = true)
+        
+        // Mock static methods
+        mockkStatic(ContextCompat::checkSelfPermission)
+    }
+
+    @Test
+    fun `hasLocationPermissions returns true when all permissions granted`() {
+        // Arrange
+        every { 
+            ContextCompat.checkSelfPermission(
+                mockContext, 
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) 
+        } returns PackageManager.PERMISSION_GRANTED
+
+        every { 
+            ContextCompat.checkSelfPermission(
+                mockContext, 
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            ) 
+        } returns PackageManager.PERMISSION_GRANTED
+
+        // Act
+        val result = PermissionManager.hasLocationPermissions(mockContext)
+
+        // Assert
+        assertTrue(result)
+    }
+
+    @Test
+    fun `hasLocationPermissions returns false when any permission not granted`() {
+        // Arrange
+        every { 
+            ContextCompat.checkSelfPermission(
+                mockContext, 
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) 
+        } returns PackageManager.PERMISSION_DENIED
+
+        every { 
+            ContextCompat.checkSelfPermission(
+                mockContext, 
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            ) 
+        } returns PackageManager.PERMISSION_GRANTED
+
+        // Act
+        val result = PermissionManager.hasLocationPermissions(mockContext)
+
+        // Assert
+        assertFalse(result)
+    }
+
+    @Test
+    fun `handlePermissionResult calls onPermissionGranted when all permissions granted`() {
+        // Arrange
+        val onGranted = mockk<() -> Unit>(relaxed = true)
+        val onDenied = mockk<() -> Unit>(relaxed = true)
+
+        // Act
+        PermissionManager.handlePermissionResult(
+            intArrayOf(PackageManager.PERMISSION_GRANTED, PackageManager.PERMISSION_GRANTED),
+            onGranted,
+            onDenied
+        )
+
+        // Assert
+        verify(exactly = 1) { onGranted() }
+        verify(exactly = 0) { onDenied() }
+    }
+
+    @Test
+    fun `handlePermissionResult calls onPermissionDenied when any permission denied`() {
+        // Arrange
+        val onGranted = mockk<() -> Unit>(relaxed = true)
+        val onDenied = mockk<() -> Unit>(relaxed = true)
+
+        // Act
+        PermissionManager.handlePermissionResult(
+            intArrayOf(PackageManager.PERMISSION_GRANTED, PackageManager.PERMISSION_DENIED),
+            onGranted,
+            onDenied
+        )
+
+        // Assert
+        verify(exactly = 0) { onGranted() }
+        verify(exactly = 1) { onDenied() }
+    }
+}


### PR DESCRIPTION


<!-- BEGIN_TITLE -->
# Implement Runtime Location Permissions for WiFi Scanning
<!-- END_TITLE -->

## Description
### Task
<!-- BEGIN_TODO -->
Implement runtime permission request for location
<!-- END_TODO -->

### Acceptance Criteria
<!-- BEGIN_ACCEPTANCE_CRITERIA -->
 - 1
 - .
 -  
 - S
 - u
 - p
 - p
 - o
 - r
 - t
 - s
 -  
 - r
 - u
 - n
 - t
 - i
 - m
 - e
 -  
 - p
 - e
 - r
 - m
 - i
 - s
 - s
 - i
 - o
 - n
 -  
 - r
 - e
 - q
 - u
 - e
 - s
 - t
 - s
 -  
 - f
 - o
 - r
 -  
 - A
 - n
 - d
 - r
 - o
 - i
 - d
 -  
 - 6
 - .
 - 0
 - +
 - 

 - 2
 - .
 -  
 - H
 - a
 - n
 - d
 - l
 - e
 - s
 -  
 - b
 - o
 - t
 - h
 -  
 - A
 - C
 - C
 - E
 - S
 - S
 - _
 - F
 - I
 - N
 - E
 - _
 - L
 - O
 - C
 - A
 - T
 - I
 - O
 - N
 -  
 - a
 - n
 - d
 -  
 - A
 - C
 - C
 - E
 - S
 - S
 - _
 - C
 - O
 - A
 - R
 - S
 - E
 - _
 - L
 - O
 - C
 - A
 - T
 - I
 - O
 - N
 - 

 - 3
 - .
 -  
 - P
 - r
 - o
 - v
 - i
 - d
 - e
 - s
 -  
 - c
 - l
 - e
 - a
 - r
 -  
 - c
 - a
 - l
 - l
 - b
 - a
 - c
 - k
 -  
 - m
 - e
 - c
 - h
 - a
 - n
 - i
 - s
 - m
 -  
 - f
 - o
 - r
 -  
 - p
 - e
 - r
 - m
 - i
 - s
 - s
 - i
 - o
 - n
 -  
 - o
 - u
 - t
 - c
 - o
 - m
 - e
 - s
 - 

 - 4
 - .
 -  
 - P
 - a
 - s
 - s
 - e
 - s
 -  
 - a
 - l
 - l
 -  
 - u
 - n
 - i
 - t
 -  
 - t
 - e
 - s
 - t
 - s
 - 

 - 5
 - .
 -  
 - F
 - o
 - l
 - l
 - o
 - w
 - s
 -  
 - A
 - n
 - d
 - r
 - o
 - i
 - d
 -  
 - p
 - e
 - r
 - m
 - i
 - s
 - s
 - i
 - o
 - n
 -  
 - m
 - a
 - n
 - a
 - g
 - e
 - m
 - e
 - n
 - t
 -  
 - b
 - e
 - s
 - t
 -  
 - p
 - r
 - a
 - c
 - t
 - i
 - c
 - e
 - s
<!-- END_ACCEPTANCE_CRITERIA -->

### Summary of Work
<!-- BEGIN_DESCRIPTION -->
This pull request implements a robust runtime permission mechanism for location access, which is critical for WiFi network scanning on Android 6.0 and above.

Key Changes:
- Created `PermissionManager` with comprehensive permission handling methods
- Implemented methods to:
  1. Check current location permissions status
  2. Request location permissions at runtime
  3. Handle permission request results
- Added support for both fine and coarse location permissions
- Provided flexible callback mechanism for permission outcomes

Implementation Details:
- Uses `ActivityCompat.requestPermissions()` for runtime permission requests
- Checks both `ACCESS_FINE_LOCATION` and `ACCESS_COARSE_LOCATION`
- Provides separate callbacks for granted and denied scenarios
- Uses request code `1001` for tracking permission requests
- Follows Android permission best practices

Test Coverage:
- Unit tests cover multiple permission scenarios
- Verifies permission checking logic
- Validates callback mechanisms for different permission states
- Uses MockK for comprehensive mocking and verification
<!-- END_DESCRIPTION -->

### Changes Made
<!-- BEGIN_CHANGES -->
 - Created PermissionManager.kt with runtime permission handling methods
 - Implemented hasLocationPermissions() to check current permission status
 - Added requestLocationPermissions() for initiating permission requests
 - Developed handlePermissionResult() to manage permission request outcomes
 - Created unit tests for permission handling scenarios
<!-- END_CHANGES -->

### Tests
<!-- BEGIN_TESTS -->
 - Verify permission check returns true when all permissions granted
 - Verify permission check returns false when any permission is denied
 - Confirm onPermissionGranted callback is called when permissions are granted
 - Confirm onPermissionDenied callback is called when any permission is denied
<!-- END_TESTS -->

## Signatures
### Staking Key
<!-- BEGIN_STAKING_KEY -->
EKjJikFMaWp6Kx3JPi6PRNqANutX8LCAsQnCd2UCu621: d6is5kta6BFjrx5tGJADoB9aBLR1nQ7GD7SKEuwJ5Bae4t1tCXiQ1jyWgKwUYhwMAWfcJS7dgrkEEP2HuY78Y2c3FZs52MAQFq4mriQHdGDcLGSUutHLoDsksqEEvBEVDo6oLPa6MoyUe8okCsWuvWaAwkVJgaY1ni4eC4L7BwSBz9YL2fjh1BMUvRaTz23JZinxSwpr6NoiY1vaYL9CAousGxs4U6Et9QzbhzoVR5reM3DQes9M6vctcupLrkpiHFT77fSzgAPwQZGXC4BUNRzQec5Y9b5RC5oJgbFAVeZXkN5sFHaJDeYrWC6v2KDqNopUF5WH9Jqc4ZSGnhXZtApSTtD67uJSj2TxfdFZwev9GQ8TCtnuvzLDihGcQ7C4i1YxyZzVnPK9FqTs6xeCu9pJC4oDamkburs2te8
<!-- END_STAKING_KEY -->

### Public Key
<!-- BEGIN_PUB_KEY -->
CXaf1KgZ3emsz9DoERxggja4xrtNYvWn8CDHzcybTqqc: 4QVp7manaKm4cLvMPJ8o53LVNizAPSBNBqWdpjxQQTb8Se2DWJgpAX2VBdixHJq2soFAvyzAJqhDr8rFrrdQeUC4fcwXvDbv2zX7GzxqsBXNxDGpTKCaTpREKhJg5UsMYHJpj2jQ8pZj4nG2vpK5qta3ZqCVao6j3mRxeirzJjDqvjdPsFaEYmsob1BU5bFGpUUNajh9g4wbSKwW3cfRQinQioEwm3UMAUPhKvivHqjyMfCC3n43AVsMeaRL8mpK7ozrBZFyj9wbEdUoBv9EcdEJALJkiDdT31dGjYokoxWapyUeiHRmLwbvoybs1bVgFvtJnSQuBBT4Jw3ey1yGfvDBtHoaMC1ycNFJneapphmCgVY9t8ZGhUcpbfj1FUkjgVnWFenstBDxpXqF9SrfcugZ9gcajgGkd6TuBYSg
<!-- END_PUB_KEY -->
